### PR TITLE
Add DS-223 RTD1618B to aarch64 and aarch64-static

### DIFF
--- a/src/dsm7/Makefile
+++ b/src/dsm7/Makefile
@@ -91,13 +91,13 @@ armv6-static:
 
 .PHONY: aarch64
 aarch64:
-	$(eval export INFO_ARCH=rtd1296 armada37xx)
+	$(eval export INFO_ARCH=rtd1296 rtd1619b armada37xx)
 	$(eval export INFO_FIRMWARE=7.0-40000)
 	@true
 
 .PHONY: aarch64-static
 aarch64-static:
-	$(eval export INFO_ARCH=rtd1296 armada37xx noarch)
+	$(eval export INFO_ARCH=rtd1296 rtd1619b armada37xx noarch)
 	$(eval export INFO_FIRMWARE=7.0-40000)
 	@true
 


### PR DESCRIPTION
This PR adds support for the RTD1618B SOC that is present in the DS223.

I've built and installed the non-static package on this synology, and it's working well!

Here's a screenshot:

![Screenshot 2023-12-18 at 4 28 26 PM](https://github.com/eizedev/AirConnect-Synology/assets/1998375/5ca32262-52fb-4809-8685-673c6d1d2b2d)
